### PR TITLE
MM-21150: Re-create the workers so that the EE workers are non-nil up…

### DIFF
--- a/api4/license.go
+++ b/api4/license.go
@@ -98,6 +98,11 @@ func addLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if *c.App.Config().JobSettings.RunJobs {
+		c.App.Srv().Jobs.Workers = c.App.Srv().Jobs.InitWorkers()
+		c.App.Srv().Jobs.StartWorkers()
+	}
+
 	c.LogAudit("success")
 	w.Write([]byte(license.ToJson()))
 }


### PR DESCRIPTION
…… (#13523)

* MM-21150: Re-create the workers so that the EE workers are non-nil upon uploading a license.

* MM-21150: Updates from Srv field to method.

Co-authored-by: mattermod <mattermod@users.noreply.github.com>

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
