### PR TITLE
User friendly error messages during OAUTH and SAML flows (#16795)

### DIFF
--- a/utils/api.go
+++ b/utils/api.go
@@ -111,6 +111,7 @@ func RenderWebError(config *model.Config, w http.ResponseWriter, r *http.Request
 	fmt.Fprintln(w, `<!DOCTYPE html><html><head></head>`)
 	fmt.Fprintln(w, `<body onload="window.location = '`+template.HTMLEscapeString(template.JSEscapeString(destination))+`'">`)
 	fmt.Fprintln(w, `<noscript><meta http-equiv="refresh" content="0; url=`+template.HTMLEscapeString(destination)+`"></noscript>`)
+	fmt.Fprintln(w, `<!-- web error message -->`)
 	fmt.Fprintln(w, `<a href="`+template.HTMLEscapeString(destination)+`" style="color: #c0c0c0;">...</a>`)
 	fmt.Fprintln(w, `</body></html>`)
 }
@@ -170,6 +171,7 @@ func RenderMobileMessage(w http.ResponseWriter, message string) {
 				</style>
 			</head>
 			<body>
+				<!-- mobile app message -->
 				<div class="container-fluid">
 					<div class="message-container">
 						`+message+`

--- a/web/oauth.go
+++ b/web/oauth.go
@@ -286,12 +286,8 @@ func completeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	renderError := func(err *model.AppError) {
-		if isMobile {
-			if hasRedirectURL {
-				utils.RenderMobileError(c.App.Config(), w, err, redirectURL)
-			} else {
-				w.Write([]byte(err.ToJson()))
-			}
+		if isMobile && hasRedirectURL {
+			utils.RenderMobileError(c.App.Config(), w, err, redirectURL)
 		} else {
 			utils.RenderWebAppError(c.App.Config(), w, r, err, c.App.AsymmetricSigningKey())
 		}

--- a/web/saml.go
+++ b/web/saml.go
@@ -111,13 +111,9 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	handleError := func(err *model.AppError) {
-		if isMobile {
+		if isMobile && hasRedirectURL {
 			err.Translate(c.App.T)
-			if hasRedirectURL {
-				utils.RenderMobileError(c.App.Config(), w, err, redirectURL)
-			} else {
-				w.Write([]byte(err.ToJson()))
-			}
+			utils.RenderMobileError(c.App.Config(), w, err, redirectURL)
 		} else {
 			c.Err = err
 			c.Err.StatusCode = http.StatusFound


### PR DESCRIPTION
* Renders error messages in webapp

* Added unit test

Co-authored-by: Mattermod <mattermod@users.noreply.github.com>

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
```
